### PR TITLE
Implement a static array class

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -47,7 +47,7 @@ CommentPragmas: '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 2
-ContinuationIndentWidth: 4
+ContinuationIndentWidth: 3
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 DisableFormat: false

--- a/README.md
+++ b/README.md
@@ -39,17 +39,17 @@ A sample program which uses the library might look like this:
 
 ```c++
 #include <iostream>
-#include <static/array.h>
+#include <static/vector.h>
 
-sstd::array<int, 100> arr;
+sstd::vector<int, 100> vec;
 
-size_t ExampleSizeOfArray(const sstd::array<int>& some_array) {
-	return some_array.size();
+size_t ExampleSizeOfVector(const sstd::vector<int>& some_vec) {
+	return some_vec.size();
 }
 
 int main() {
 	// Size: 100
-	std::cout << "Size: " << ExampleSizeOfArray(arr) << std::endl;
+	std::cout << "Size: " << ExampleSizeOfVector(vec) << std::endl;
 }
 ```
 

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -187,7 +187,7 @@ SHORT_NAMES            = NO
 # description.)
 # The default value is: NO.
 
-JAVADOC_AUTOBRIEF      = NO
+JAVADOC_AUTOBRIEF      = YES
 
 # If the QT_AUTOBRIEF tag is set to YES then doxygen will interpret the first
 # line (until the first dot) of a Qt-style comment as the brief description. If
@@ -195,7 +195,7 @@ JAVADOC_AUTOBRIEF      = NO
 # requiring an explicit \brief command for a brief description.)
 # The default value is: NO.
 
-QT_AUTOBRIEF           = NO
+QT_AUTOBRIEF           = YES
 
 # The MULTILINE_CPP_IS_BRIEF tag can be set to YES to make doxygen treat a
 # multi-line C++ special comment block (i.e. a block of //! or /// comments) as

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -187,7 +187,7 @@ SHORT_NAMES            = NO
 # description.)
 # The default value is: NO.
 
-JAVADOC_AUTOBRIEF      = YES
+JAVADOC_AUTOBRIEF      = NO
 
 # If the QT_AUTOBRIEF tag is set to YES then doxygen will interpret the first
 # line (until the first dot) of a Qt-style comment as the brief description. If
@@ -195,7 +195,7 @@ JAVADOC_AUTOBRIEF      = YES
 # requiring an explicit \brief command for a brief description.)
 # The default value is: NO.
 
-QT_AUTOBRIEF           = YES
+QT_AUTOBRIEF           = NO
 
 # The MULTILINE_CPP_IS_BRIEF tag can be set to YES to make doxygen treat a
 # multi-line C++ special comment block (i.e. a block of //! or /// comments) as

--- a/doc/groups.dox
+++ b/doc/groups.dox
@@ -1,3 +1,9 @@
+/** @defgroup algorithm Algorithms
+ *
+ * Defines functions that operate on ranges of elements for a variety of
+ * purposes.
+ */
+
 /** @defgroup container Containers
  *
  * Generic collection of class templates which allow the user to implement

--- a/doc/groups.dox
+++ b/doc/groups.dox
@@ -16,3 +16,9 @@
  * Sequence containers implement data structures which can be accessed
  * sequentially.
  */
+
+/** @defgroup iterator Iterators
+ *
+ * Provides definitions for iterators, as well as iterator traits, adapters, and
+ * utility functions.
+ */

--- a/inc/static/algorithm.h
+++ b/inc/static/algorithm.h
@@ -1,0 +1,98 @@
+/** @file    algorithm.h
+ *  @brief   This header is a part of the algorithms library.
+ *  @ingroup algorithm
+ */
+
+#ifndef STATIC_ALGORITHM_H_
+#define STATIC_ALGORITHM_H_
+
+#include "iterator.h"
+
+namespace sstd {
+
+/** @brief  Returns true if the range [first1, last1] is equal to the range
+ *          beginning at first2.
+ *  @tparam InputIt1  Must meet the requirements of InputIterator.
+ *  @tparam InputIt2  Must meet the requirements of InputIterator.
+ */
+template<class InputIt1, class InputIt2>
+bool equal(InputIt1 first1, InputIt1 last1, InputIt2 first2) {
+	for (; first1 != last1; ++first1, ++first2) {
+		if (!(*first1 == *first2)) { return false; }
+	}
+
+	return true;
+}
+
+/** @brief  Returns true if the range [first1, last1] is equal to the range
+ *          beginning at first2, via binary predicate.
+ *  @tparam InputIt1  Must meet the requirements of InputIterator.
+ *  @tparam InputIt2  Must meet the requirements of InputIterator.
+ *  @tparam BinaryPredicate  Binary predicate which returns true if the elements
+ *                           are equal.
+ */
+template<class InputIt1, class InputIt2, class BinaryPredicate>
+bool equal(InputIt1 first1,
+           InputIt1 last1,
+           InputIt2 first2,
+           BinaryPredicate p) {
+	for (; first1 != last1; ++first1, ++first2) {
+		if (!p(*first1, *first2)) { return false; }
+	}
+
+	return true;
+}
+
+/** @brief  Checks if the first range [first1, last1] is lexicographically less
+ *          than the second range [first2, last2].
+ *  @tparam InputIt1  Must meet the requirements of InputIterator.
+ *  @tparam InputIt2  Must meet the requirements of InputIterator.
+ *  @param  first1  Begin of first range to examine.
+ *  @param  last1  End of first range to examine.
+ *  @param  first2  Begin of second range to examine.
+ *  @param  last2  End of second range to examine.
+ */
+template<class InputIt1, class InputIt2>
+bool lexicographical_compare(InputIt1 first1,
+                             InputIt1 last1,
+                             InputIt2 first2,
+                             InputIt2 last2) {
+	for (; (first1 != last1) && (first2 != last2); ++first1, ++first2) {
+		if (*first1 < *first2) { return true; }
+
+		if (*first2 < *first1) { return false; }
+	}
+
+	return (first1 == last1) && (first2 != last2);
+}
+
+/** @brief  Checks if the first range [first1, last1] is lexicographically less
+ *          than the second range [first2, last2], via comparison functor.
+ *  @tparam InputIt1  Must meet the requirements of InputIterator.
+ *  @tparam InputIt2  Must meet the requirements of InputIterator.
+ *  @tparam Compare  Binary predicate which returns true if the first argument
+ *                   is less than the second.
+ *  @param  first1  Begin of first range to examine.
+ *  @param  last1  End of first range to examine.
+ *  @param  first2  Begin of second range to examine.
+ *  @param  last2  End of second range to examine.
+ *  @param  comp  Comparison function object.
+ */
+template<class InputIt1, class InputIt2, class Compare>
+bool lexicographical_compare(InputIt1 first1,
+                             InputIt1 last1,
+                             InputIt2 first2,
+                             InputIt2 last2,
+                             Compare comp) {
+	for (; (first1 != last1) && (first2 != last2); ++first1, ++first2) {
+		if (comp(*first1, *first2)) { return true; }
+
+		if (comp(*first2, *first1)) { return false; }
+	}
+
+	return (first1 == last1) && (first2 != last2);
+}
+
+} /* namespace sstd */
+
+#endif /* STATIC_ALGORITHM_H_ */

--- a/inc/static/array.h
+++ b/inc/static/array.h
@@ -1,0 +1,134 @@
+/** @file    array.h
+ *  @brief   This header is a part of the containers library.
+ *  @ingroup sequence_container
+ */
+
+#ifndef STATIC_ARRAY_H_
+#define STATIC_ARRAY_H_
+
+#include <stddef.h>
+
+#include "algorithm.h"
+#include "iterator.h"
+
+namespace sstd {
+
+/** @brief  Static contiguous array.
+ *  @tparam T  Type stored by the container.
+ *  @tparam N  Number of elements in the container.
+ *
+ * A container that encapsulates fixed size arrays. This container is an
+ * aggregate type with the same semantics as a struct holding a C-style array as
+ * its only non-static data member. This is a direct replacement for an
+ * std::array in cases where it is unavailable.
+ */
+template<class T, size_t N>
+class array {
+  public:
+	typedef T value_type;
+	typedef size_t size_type;
+	typedef ptrdiff_t difference_type;
+	typedef value_type& reference;
+	typedef const value_type& const_reference;
+	typedef value_type* pointer;
+	typedef const value_type* const_pointer;
+	typedef pointer iterator;
+	typedef const_pointer const_iterator;
+	typedef sstd::reverse_iterator<iterator> reverse_iterator;
+	typedef sstd::reverse_iterator<const_iterator> const_reverse_iterator;
+
+	/** @brief Access specified element with bounds checking.
+	 *  @param pos Position of the element within the container.
+	 */
+	reference at(size_type pos) { return buf_[pos % N]; }
+	const_reference at(size_type pos) const { return buf_[pos % N]; }
+
+	/** @brief Access specified element.
+	 *  @param pos Position of the element within the container.
+	 */
+	reference operator[](size_type pos) { return buf_[pos]; }
+	const_reference operator[](size_type pos) const { return buf_[pos]; }
+
+	/** @brief Access the first element. */
+	reference front() { return buf_[0]; }
+	const_reference front() const { return buf_[0]; }
+
+	/** @brief Access the last element. */
+	reference back() { return buf_[N - 1]; }
+	const_reference back() const { return buf_[N - 1]; }
+
+	/** @brief Access the underlying array pointer. */
+	pointer data() { return buf_; }
+	const_pointer data() const { return buf_; }
+
+	/** @brief Returns an iterator to the first element. */
+	iterator begin() { return buf_; }
+	const_iterator begin() const { return buf_; }
+	const_iterator cbegin() const { return buf_; }
+
+	/** @brief Returns an iterator to one past the last element. */
+	iterator end() { return buf_ + N; }
+	const_iterator end() const { return buf_ + N; }
+	const_iterator cend() const { return buf_ + N; }
+
+	/** @brief Returns a reverse iterator to the first element. */
+	reverse_iterator rbegin() { return reverse_iterator(end()); }
+	const_reverse_iterator rbegin() const {
+		return const_reverse_iterator(end());
+	}
+	const_reverse_iterator crbegin() const { return rbegin(); }
+
+	/** @brief Returns a reverse iterator to one past the last element. */
+	reverse_iterator rend() { return reverse_iterator(begin()); }
+	const_reverse_iterator rend() const {
+		return const_reverse_iterator(begin());
+	}
+	const_reverse_iterator crend() const { return rend(); }
+
+	/** @brief Checks whether the container has no elements. */
+	bool empty() const { return false; }
+
+	/** @brief Returns the number of elements in the container. */
+	size_type size() const { return N; }
+
+	/** @brief Returns the maximum possible number of elements. */
+	size_type max_size() const { return N; }
+
+	T buf_[N];
+};
+
+template<class T, size_t N, class T2, size_t N2>
+inline bool operator==(const array<T, N>& lhs, const array<T2, N2>& rhs) {
+	return lhs.size() == rhs.size() &&
+	       equal(lhs.cbegin(), lhs.cend(), rhs.cbegin());
+}
+
+template<class T, size_t N, class T2, size_t N2>
+inline bool operator!=(const array<T, N>& lhs, const array<T2, N2>& rhs) {
+	return !(lhs == rhs);
+}
+
+template<class T, size_t N, class T2, size_t N2>
+inline bool operator<(const array<T, N>& lhs, const array<T2, N2>& rhs) {
+	return lexicographical_compare(
+	   lhs.cbegin(), lhs.cend(), rhs.cbegin(), rhs.cend());
+}
+
+template<class T, size_t N, class T2, size_t N2>
+inline bool operator>(const array<T, N>& lhs, const array<T2, N2>& rhs) {
+	return rhs < lhs;
+}
+
+template<class T, size_t N, class T2, size_t N2>
+inline bool operator<=(const array<T, N>& lhs, const array<T2, N2>& rhs) {
+	return !(rhs < lhs);
+}
+
+template<class T, size_t N, class T2, size_t N2>
+inline bool operator>=(const array<T, N>& lhs, const array<T2, N2>& rhs) {
+	return !(lhs < rhs);
+}
+
+} /* namespace sstd */
+
+#endif /* STATIC_ARRAY_H_ */

--- a/inc/static/iterator.h
+++ b/inc/static/iterator.h
@@ -1,0 +1,182 @@
+/** @file    iterator.h
+ *  @brief   This header is a part of the iterator library.
+ *  @ingroup iterator
+ */
+
+#ifndef STATIC_ITERATOR_H_
+#define STATIC_ITERATOR_H_
+
+#include <stddef.h>
+
+namespace sstd {
+
+/** @brief An Iterator that can read from the pointed-to element. */
+struct input_iterator_tag {};
+
+/** @brief An Iterator that can write to the pointed-to element. */
+struct output_iterator_tag {};
+
+/** @brief An InputIterator that can be incremented to the next element. */
+struct forward_iterator_tag : public input_iterator_tag {};
+
+/** @brief A ForwardIterator that can be moved in both directions. */
+struct bidirectional_iterator_tag : public forward_iterator_tag {};
+
+/** @brief A BidirectionalIterator that can move to point to any element in
+ *         constant time.
+ */
+struct random_access_iterator_tag : public bidirectional_iterator_tag {};
+
+/** @brief  Type trait class that provides uniform interface to the properties
+ *          of Iterator types.
+ *  @tparam Iterator  The type of the Iterator whose traits are being queried.
+ */
+template<class Iterator>
+struct iterator_traits {
+	typedef typename Iterator::iterator_category iterator_category;
+	typedef typename Iterator::value_type value_type;
+	typedef typename Iterator::pointer pointer;
+	typedef typename Iterator::reference reference;
+	typedef typename Iterator::difference_type difference_type;
+};
+
+/** @brief Specialization for iterators that are a pointer. */
+template<typename T>
+struct iterator_traits<T*> {
+	typedef random_access_iterator_tag iterator_category;
+	typedef T value_type;
+	typedef T* pointer;
+	typedef T& reference;
+	typedef ptrdiff_t difference_type;
+};
+
+/** @brief Specialization for iterators that are a const pointer. */
+template<typename T>
+struct iterator_traits<const T*> {
+	typedef random_access_iterator_tag iterator_category;
+	typedef T value_type;
+	typedef const T* pointer;
+	typedef const T& reference;
+	typedef ptrdiff_t difference_type;
+};
+
+/** @brief  An Iterator adaptor that reverses the direction of an iterator.
+ *  @tparam Iterator  The type of the Iterator to be reversed.
+ */
+template<class Iterator>
+class reverse_iterator {
+  public:
+	typedef
+	   typename iterator_traits<Iterator>::iterator_category iterator_category;
+	typedef typename iterator_traits<Iterator>::value_type value_type;
+	typedef typename iterator_traits<Iterator>::pointer pointer;
+	typedef typename iterator_traits<Iterator>::reference reference;
+	typedef typename iterator_traits<Iterator>::difference_type difference_type;
+
+	/** @brief Default construct. */
+	reverse_iterator() : it_() {}
+
+	/** @brief Construct from an Iterator. */
+	explicit reverse_iterator(Iterator it) : it_(it) {}
+
+	/** @brief Returns the underlying base iterator. */
+	Iterator base() const { return it_; }
+
+	/** @brief Returns a reference to the element previous to current. */
+	reference operator*() const {
+		Iterator tmp(it_);
+		return *--tmp;
+	}
+
+	/** @brief Returns a pointer to the element previous to current. */
+	pointer operator->() const { return &(operator*()); }
+
+	/** @brief Returns a reference to the element at the specified relative
+	 *         location. */
+	reference operator[](difference_type n) const { return it_[-n - 1]; }
+
+	/** @brief Pre-increments the iterator, applied in reverse. */
+	reverse_iterator& operator++() {
+		--it_;
+		return *this;
+	}
+
+	/** @brief Post-increments the iterator, applied in reverse. */
+	reverse_iterator operator++(int) {
+		reverse_iterator tmp(*this);
+		--it_;
+		return *tmp;
+	}
+
+	/** @brief Advances the iterator by n positions. */
+	reverse_iterator& operator+=(difference_type n) { return it_ -= n; }
+
+	/** @brief Returns an iterator which is advanced by n positions. */
+	reverse_iterator operator+(difference_type n) const {
+		return reverse_iterator(it_ - n);
+	}
+
+	/** @brief Pre-decrements the iterator, applied in reverse. */
+	reverse_iterator& operator--() {
+		++it_;
+		return *this;
+	}
+
+	/** @brief Post-decrements the iterator, applied in reverse. */
+	reverse_iterator operator--(int) {
+		reverse_iterator tmp(*this);
+		++it_;
+		return *tmp;
+	}
+
+	/** @brief Advances the iterator by -n positions. */
+	reverse_iterator& operator-=(difference_type n) { return it_ += n; }
+
+	/** @brief Returns an iterator which is advanced by -n positions. */
+	reverse_iterator operator-(difference_type n) const {
+		return reverse_iterator(it_ + n);
+	}
+
+  protected:
+	Iterator it_;
+};
+
+template<class Iterator1, class Iterator2>
+bool operator==(const reverse_iterator<Iterator1>& lhs,
+                const reverse_iterator<Iterator2>& rhs) {
+	return lhs.base() == rhs.base();
+}
+
+template<class Iterator1, class Iterator2>
+bool operator!=(const reverse_iterator<Iterator1>& lhs,
+                const reverse_iterator<Iterator2>& rhs) {
+	return !(lhs == rhs);
+}
+
+template<class Iterator1, class Iterator2>
+bool operator<(const reverse_iterator<Iterator1>& lhs,
+               const reverse_iterator<Iterator2>& rhs) {
+	return lhs.base() < rhs.base();
+}
+
+template<class Iterator1, class Iterator2>
+bool operator>(const reverse_iterator<Iterator1>& lhs,
+               const reverse_iterator<Iterator2>& rhs) {
+	return rhs < lhs;
+}
+
+template<class Iterator1, class Iterator2>
+bool operator<=(const reverse_iterator<Iterator1>& lhs,
+                const reverse_iterator<Iterator2>& rhs) {
+	return !(rhs < lhs);
+}
+
+template<class Iterator1, class Iterator2>
+bool operator>=(const reverse_iterator<Iterator1>& lhs,
+                const reverse_iterator<Iterator2>& rhs) {
+	return !(lhs < rhs);
+}
+
+} /* namespace sstd */
+
+#endif /* STATIC_ITERATOR_H_ */

--- a/test/algorithm.cpp
+++ b/test/algorithm.cpp
@@ -1,0 +1,61 @@
+#include "static/algorithm.h"
+
+#include <catch/catch.hpp>
+
+TEST_CASE("Check for equality", "[comparison]") {
+	const size_t count = 3;
+	int a[count]       = {0, 1, 2};
+
+	SECTION("When the values are equal") {
+		int b[count] = {0, 1, 2};
+
+		REQUIRE(sstd::equal(&a[0], &a[count], &b[0]));
+	}
+
+	SECTION("When the values are not equal") {
+		int b[count] = {0};
+
+		REQUIRE(!sstd::equal(&a[0], &a[count], &b[0]));
+	}
+}
+
+TEST_CASE("Lexicographically compare values", "[comparison]") {
+	const size_t count = 5;
+	int a[count]       = {0, 1, 2, 3, 4};
+
+	SECTION("First mismatching element defines which is less than") {
+		SECTION("First array less than") {
+			int b[count] = {0, 7, 2, 3, 4};
+
+			REQUIRE(sstd::lexicographical_compare(
+			   &a[0], &a[count], &b[0], &b[count]));
+		}
+
+		SECTION("Second array less than") {
+			int b[count] = {0, 1, 0, 3, 4};
+
+			REQUIRE(!sstd::lexicographical_compare(
+			   &a[0], &a[count], &b[0], &b[count]));
+		}
+	}
+
+	SECTION("If one range is a prefix of the other, the shorter is less than") {
+		REQUIRE(sstd::lexicographical_compare(&a[0], &a[2], &a[0], &a[count]));
+		REQUIRE(!sstd::lexicographical_compare(&a[0], &a[count], &a[0], &a[1]));
+	}
+
+	SECTION("If two ranges have the same elements and length, they are equal") {
+		REQUIRE(
+		   !sstd::lexicographical_compare(&a[0], &a[count], &a[0], &a[count]));
+	}
+
+	SECTION("An empty range is less than any non-empty range") {
+		REQUIRE(sstd::lexicographical_compare(&a[0], &a[0], &a[0], &a[count]));
+		REQUIRE(!sstd::lexicographical_compare(&a[0], &a[count], &a[0], &a[0]));
+	}
+
+	SECTION("Two empty ranges are equal") {
+		REQUIRE(!sstd::lexicographical_compare(a, a, &a[3], &a[3]));
+		REQUIRE(!sstd::lexicographical_compare(&a[3], &a[3], a, a));
+	}
+}

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -1,0 +1,186 @@
+#include "static/array.h"
+
+#include <catch/catch.hpp>
+
+TEST_CASE("Construct an array", "[constructor]") {
+	SECTION("Default construct") {
+		sstd::array<char, 3> a;
+
+		REQUIRE(a.data());
+	}
+
+	SECTION("Aggregate initialize") {
+		sstd::array<int, 3> a = {16, 16, 16};
+
+		REQUIRE(a[0] == 16);
+		REQUIRE(a[1] == 16);
+		REQUIRE(a[2] == 16);
+	}
+
+	SECTION("Copy construct") {
+		sstd::array<unsigned char, 3> a = {0, 1, 2};
+		sstd::array<unsigned char, 3> b(a);
+
+		REQUIRE(a[0] == b[0]);
+		REQUIRE(a[1] == b[1]);
+		REQUIRE(a[2] == b[2]);
+	}
+}
+
+TEST_CASE("Assign an array", "[assignment]") {
+	sstd::array<char, 3> a = {0, 1, 2};
+	sstd::array<char, 3> b = {2, 1, 0};
+
+	b = a;
+
+	REQUIRE(a[0] == b[0]);
+	REQUIRE(a[1] == b[1]);
+	REQUIRE(a[2] == b[2]);
+}
+
+TEST_CASE("Index into an array", "[access]") {
+	const size_t count = 3;
+	sstd::array<int, count> a;
+
+	for (size_t i = 0; i < count; ++i) { a.data()[i] = ~i; }
+
+	SECTION("Using random access operator") {
+		REQUIRE(a[0] == ~0);
+		REQUIRE(a[1] == ~1);
+		REQUIRE(a[2] == ~2);
+	}
+
+	SECTION("Using bounds checked method") {
+		SECTION("Within bounds") {
+			REQUIRE(a.at(0) == ~0);
+			REQUIRE(a.at(1) == ~1);
+			REQUIRE(a.at(2) == ~2);
+		}
+
+		SECTION("Out of bounds") {
+			int overflow = a.data()[0];
+			a.at(count)  = ~overflow;
+
+			REQUIRE(a.at(count) == a.data()[0]);
+		}
+	}
+}
+
+TEST_CASE("Iterate over an array", "[iterator]") {
+	typedef sstd::array<int, 3> array;
+	array a = {4, 4, 4};
+
+	SECTION("Forward direction") {
+		for (array::iterator it = a.begin(); it != a.end(); ++it) { *it = 16; }
+
+		REQUIRE(a[0] == 16);
+		REQUIRE(a[1] == 16);
+		REQUIRE(a[2] == 16);
+	}
+
+	SECTION("Reverse direction") {
+		int i = 0;
+
+		for (array::reverse_iterator it = a.rbegin(); it != a.rend();
+		     ++it, ++i) {
+			*it = i;
+		}
+
+		REQUIRE(a[0] == 2);
+		REQUIRE(a[1] == 1);
+		REQUIRE(a[2] == 0);
+	}
+
+	SECTION("With const-qualified array") {
+		const array b = {16, 16, 16};
+
+		size_t count = 0;
+
+		for (array::const_iterator it = b.begin(); it != b.end(); ++it) {
+			if (*it == 16) { ++count; }
+		}
+
+		REQUIRE(count == 3);
+	}
+}
+
+TEST_CASE("Check the capacity of an array", "[capacity]") {
+	sstd::array<int, 8> a;
+
+	REQUIRE(!a.empty());
+	REQUIRE(a.size() == 8);
+	REQUIRE(a.max_size() == 8);
+}
+
+TEST_CASE("Test arrays for equality", "[comparison]") {
+	sstd::array<char, 3> a = {16, 16, 16};
+
+	SECTION("With an equal size array") {
+		SECTION("With same contents") {
+			sstd::array<char, 3> b = {16, 16, 16};
+
+			REQUIRE(a == b);
+		}
+
+		SECTION("With differing contents") {
+			sstd::array<char, 3> b = {32, 32, 32};
+
+			REQUIRE(a != b);
+		}
+	}
+
+	SECTION("With a smaller size array") {
+		sstd::array<char, 2> b = {16, 16};
+
+		REQUIRE(a != b);
+	}
+
+	SECTION("With a larger size array") {
+		sstd::array<char, 5> b = {16, 16, 16, 16, 16};
+
+		REQUIRE(a != b);
+	}
+}
+
+TEST_CASE("Compare arrays lexicographically", "[comparison]") {
+	sstd::array<int, 4> a = {16, 16, 16, 16};
+
+	SECTION("With an equal size array") {
+		SECTION("With lower value") {
+			sstd::array<int, 4> b = {8, 8, 8, 8};
+
+			REQUIRE(a > b);
+			REQUIRE(a >= b);
+			REQUIRE(b < a);
+			REQUIRE(b <= a);
+		}
+
+		SECTION("With higher value") {
+			sstd::array<int, 4> b = {32, 32, 32, 32};
+
+			REQUIRE(a < b);
+			REQUIRE(a <= b);
+			REQUIRE(b > a);
+			REQUIRE(b >= a);
+		}
+
+		SECTION("With equal value") {
+			sstd::array<int, 4> b = {16, 16, 16, 16};
+
+			REQUIRE(a <= b);
+			REQUIRE(a >= b);
+		}
+	}
+
+	SECTION("With s smaller size array") {
+		sstd::array<int, 2> b = {16, 16};
+
+		REQUIRE(b < a);
+	}
+
+	SECTION("With s larger size array") {
+		sstd::array<int, 8> b = {16, 16, 16, 16, 16, 16, 16, 16};
+
+		REQUIRE(a < b);
+	}
+}

--- a/test/iterator.cpp
+++ b/test/iterator.cpp
@@ -1,0 +1,16 @@
+#include "static/iterator.h"
+
+#include <catch/catch.hpp>
+
+#include "static/algorithm.h"
+
+TEST_CASE("Iterate in reverse", "[iterator]") {
+	const size_t count = 4;
+	int a[count]       = {2, 4, 8, 16};
+	int b[count]       = {16, 8, 4, 2};
+
+	sstd::reverse_iterator<int*> begin(a + count);
+	sstd::reverse_iterator<int*> end(a);
+
+	REQUIRE(sstd::equal(begin, end, b));
+}


### PR DESCRIPTION
This brings in an implementation of a static array, which is nearly identical to the STL implementation. I changed the README to reference a vector instead of array, because I decided against making arrays have a size-agnostic interface.